### PR TITLE
[Andrey Eremeev] Fix call of method delete_all. 

### DIFF
--- a/lib/orm_proxy.rb
+++ b/lib/orm_proxy.rb
@@ -89,7 +89,7 @@ class ORMProxy
       habtm_model = [model_name, habtm].sort.join("_")
       habtm_class = habtm_model.singularize.classify.constantize
 
-      habtm_class.delete_all(["#{model_key} = ?", record.id])
+      habtm_class.where(["#{model_key} = ?", record.id]).delete_all
       habtm_key = habtm_key(habtm)
 
       values.each do |value|


### PR DESCRIPTION
In ActiveRecord::VERSION::STRING >= '5.1.7' method delete_all has no arguments.